### PR TITLE
chore: update WordPress tested version to 6.9

### DIFF
--- a/omnisend-for-ninja-forms/class-omnisend-ninjaformsaddon-bootstrap.php
+++ b/omnisend-for-ninja-forms/class-omnisend-ninjaformsaddon-bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Omnisend for Ninja Forms Add-On
  * Description: A ninja forms add-on to sync contacts with Omnisend. In collaboration with Omnisend for WooCommerce plugin it enables better customer tracking
- * Version: 1.1.6
+ * Version: 1.1.7
  * Author: Omnisend
  * Author URI: https://omnisend.com
  * Developer: Omnisend
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 const OMNISEND_NINJA_ADDON_NAME    = 'Omnisend for NINJA Forms Add-On';
-const OMNISEND_NINJA_ADDON_VERSION = '1.1.6';
+const OMNISEND_NINJA_ADDON_VERSION = '1.1.7';
 
 add_action( 'ninja_forms_register_actions', array( 'Omnisend_NinjaFormsAddOn_Bootstrap', 'register_actions' ), 10 );
 spl_autoload_register( array( 'Omnisend_NinjaFormsAddOn_Bootstrap', 'autoloader' ) );

--- a/omnisend-for-ninja-forms/readme.txt
+++ b/omnisend-for-ninja-forms/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Ninja Forms Add-On
 Contributors: Omnisend
 Tags: Ninja forms, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 6.7
+Tested up to: 6.9
 Requires PHP: 7.1
-Stable tag: 1.1.6
+Stable tag: 1.1.7
 License: GPLv3 or later
 URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -60,6 +60,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.1.7 =
+* Tested up to WordPress 6.9
 
 = 1.1.6 =
 * Update screenshots


### PR DESCRIPTION
## What?
Update WordPress tested version to 6.9 and bump plugin version to 1.1.7.

## Why?
Plugin has been tested with WordPress 6.9.