### PR TITLE
Update for WordPress 7.0 compatibility

### DIFF
--- a/omnisend-for-ninja-forms/class-omnisend-ninjaformsaddon-bootstrap.php
+++ b/omnisend-for-ninja-forms/class-omnisend-ninjaformsaddon-bootstrap.php
@@ -2,7 +2,8 @@
 /**
  * Plugin Name: Omnisend for Ninja Forms Add-On
  * Description: A ninja forms add-on to sync contacts with Omnisend. In collaboration with Omnisend for WooCommerce plugin it enables better customer tracking
- * Version: 1.1.7
+ * Version: 1.1.8
+ * Requires PHP: 7.4
  * Author: Omnisend
  * Author URI: https://omnisend.com
  * Developer: Omnisend
@@ -23,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 const OMNISEND_NINJA_ADDON_NAME    = 'Omnisend for NINJA Forms Add-On';
-const OMNISEND_NINJA_ADDON_VERSION = '1.1.7';
+const OMNISEND_NINJA_ADDON_VERSION = '1.1.8';
 
 add_action( 'ninja_forms_register_actions', array( 'Omnisend_NinjaFormsAddOn_Bootstrap', 'register_actions' ), 10 );
 spl_autoload_register( array( 'Omnisend_NinjaFormsAddOn_Bootstrap', 'autoloader' ) );

--- a/omnisend-for-ninja-forms/readme.txt
+++ b/omnisend-for-ninja-forms/readme.txt
@@ -36,7 +36,7 @@ Omnisend for Ninja Forms add-on requires you to install:
 Read [Installation instructions](https://support.omnisend.com/en/articles/8775209-integration-with-ninja-forms)
 
 = What are the technical requirements for the plugin installation? =
-* PHP 7.1+
+* PHP 7.4+
 * WordPress 4.0.1+
 * Omnisend account
 

--- a/omnisend-for-ninja-forms/readme.txt
+++ b/omnisend-for-ninja-forms/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Ninja Forms Add-On
 Contributors: Omnisend
 Tags: Ninja forms, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 6.9
-Requires PHP: 7.1
-Stable tag: 1.1.7
+Tested up to: 7.0
+Requires PHP: 7.4
+Stable tag: 1.1.8
 License: GPLv3 or later
 URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -60,6 +60,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.1.8 =
+* Updated for WordPress 7.0 compatibility.
+* Bumped minimum PHP requirement to 7.4.
 
 = 1.1.7 =
 * Tested up to WordPress 6.9


### PR DESCRIPTION
## What?

Update plugin for WordPress 7.0 compatibility:
- Add `Requires PHP: 7.4` header
- Update `Tested up to: 7.0`
- Version bump 1.1.7 → 1.1.8

## Why?

WordPress 7.0 raises the minimum PHP version to 7.4. This update declares compatibility with WP 7.0 and aligns the PHP requirement.

Initiated-by:paulius.l@omnisend.com

Link to Devin session: https://app.devin.ai/sessions/e77377e050884548b15f4db75899626a
Requested by: @plutzilla