### PR TITLE
Update for WordPress 7.1 compatibility

### DIFF
--- a/omnisend-for-ninja-forms/class-omnisend-ninjaformsaddon-bootstrap.php
+++ b/omnisend-for-ninja-forms/class-omnisend-ninjaformsaddon-bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Omnisend for Ninja Forms Add-On
  * Description: A ninja forms add-on to sync contacts with Omnisend. In collaboration with Omnisend for WooCommerce plugin it enables better customer tracking
- * Version: 1.2.0
+ * Version: 1.2.1
  * Requires PHP: 7.4
  * Author: Omnisend
  * Author URI: https://omnisend.com
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 const OMNISEND_NINJA_ADDON_NAME    = 'Omnisend for NINJA Forms Add-On';
-const OMNISEND_NINJA_ADDON_VERSION = '1.2.0';
+const OMNISEND_NINJA_ADDON_VERSION = '1.2.1';
 
 add_action( 'ninja_forms_register_actions', array( 'Omnisend_NinjaFormsAddOn_Bootstrap', 'register_actions' ), 10 );
 spl_autoload_register( array( 'Omnisend_NinjaFormsAddOn_Bootstrap', 'autoloader' ) );

--- a/omnisend-for-ninja-forms/readme.txt
+++ b/omnisend-for-ninja-forms/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Ninja Forms Add-On
 Contributors: Omnisend
 Tags: Ninja forms, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv3 or later
 URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -60,6 +60,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.2.1 =
+* Confirmed compatibility with WordPress 7.1.
 
 = 1.2.0 =
 * Suggest privacy policy text via the WordPress privacy policy content API.


### PR DESCRIPTION
## What?

- Bump `Tested up to: 7.1` in readme.txt
- Requires PHP unchanged at 7.4 — WP 7.1 minimum is still 7.4
- Patch version 1.2.0 → 1.2.1

## Why?

WordPress 7.1 (Field Guide: https://make.wordpress.org/core/2026/08/05/wordpress-7-1-field-guide/). Audit: no matching surfaces; PHP-hook only.