### PR TITLE
docs: add GitHub README plugin description and wordpress.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Connects Ninja Forms submissions to Omnisend so form contacts can be synced for email/SMS marketing.
 
-Requires the [Omnisend](https://wordpress.org/plugins/omnisend/) plugin.
+Requires [Ninja Forms](https://wordpress.org/plugins/ninja-forms/) and the [Omnisend](https://wordpress.org/plugins/omnisend/) plugin.
 
 WordPress plugin: https://wordpress.org/plugins/omnisend-for-ninja-forms-add-on/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# Omnisend Add-on for Ninja Forms WordPress plugin
+# Omnisend for Ninja Forms Add-On
 
-Link to plugin in Wordpress app store: [link](https://wordpress.org/plugins/omnisend-for-ninja-forms-add-on/).
+Connects Ninja Forms submissions to Omnisend so form contacts can be synced for email/SMS marketing.
+
+Requires the [Omnisend](https://wordpress.org/plugins/omnisend/) plugin.
+
+WordPress plugin: https://wordpress.org/plugins/omnisend-for-ninja-forms-add-on/


### PR DESCRIPTION
## What?

Add a short GitHub README description and a wordpress.org plugin directory link.

## Why?

The GitHub README had no useful plugin description or wordpress.org link.